### PR TITLE
On error, write the command that was used

### DIFF
--- a/gitnu/app/gitcommands/optionscommand.dart
+++ b/gitnu/app/gitcommands/optionscommand.dart
@@ -19,7 +19,7 @@ class OptionsCommand extends GitCommandBase implements ShellCommand {
   }
 
   void help() {
-    String helpText = """usage: git set ${html('<name> <email>')}
+    String helpText = """usage: git options ${html('<name> <email>')}
         <pre class="help">${getArgParser().getUsage()}</pre>""";
     _output.printHtml(helpText);
   }
@@ -38,7 +38,7 @@ class OptionsCommand extends GitCommandBase implements ShellCommand {
     }
 
     if (commandLineOptions.rest.length != 2)
-      throw new Exception("set: wrong number of arguments.");
+      throw new Exception("options: wrong number of arguments.");
 
     _options.name = commandLineOptions.rest[0];
     _options.email = commandLineOptions.rest[1];

--- a/gitnu/app/gitcommands/pullcommand.dart
+++ b/gitnu/app/gitcommands/pullcommand.dart
@@ -50,7 +50,7 @@ class PullCommand extends GitCommandBase implements ShellCommand {
         // TODO(camfitz): Do something with the result.
         window.console.debug("$value");
       }, onError: (e) {
-        _output.printLine("push error: $e");
+        _output.printLine("pull error: $e");
       });
     });
   }


### PR DESCRIPTION
I'm getting the wrong error message when issuing a pull and options command. Here is the fix. See issue #10 as this addresses the problem.
